### PR TITLE
Fixes for PySCF 2.5

### DIFF
--- a/tests/expressions/test_ccsd.py
+++ b/tests/expressions/test_ccsd.py
@@ -6,6 +6,7 @@ import unittest
 import pytest
 
 from pyscf import gto, scf, cc, lib
+from pyscf.cc.momgfccsd import MomGFCCSD
 import numpy as np
 import scipy.linalg
 
@@ -90,7 +91,7 @@ class CCSD_Tests(unittest.TestCase):
         eta = 1e-1
         sf = util.build_spectral_function(gf.energies, gf.couplings, grid, eta=eta)
 
-        momgfcc = cc.momgfccsd.MomGFCCSD(ccsd, ((nmom-2)//2, (nmom-2)//2))
+        momgfcc = MomGFCCSD(ccsd, ((nmom-2)//2, (nmom-2)//2))
         eh, vh, ep, vp = momgfcc.kernel()
         e = np.concatenate((eh, ep), axis=0)
         v = np.concatenate((vh[0], vp[0]), axis=1)

--- a/tests/util/test_energy.py
+++ b/tests/util/test_energy.py
@@ -23,7 +23,7 @@ class Energy_Tests(unittest.TestCase):
         mf = scf.RHF(mol)
         mf.conv_tol = 1e-14
         mf.kernel()
-        h = np.linalg.multi_dot((mf.mo_coeff.T, mol.get_hcore(), mf.mo_coeff))
+        h = np.linalg.multi_dot((mf.mo_coeff.T, mf.get_hcore(), mf.mo_coeff))
         f = np.diag(mf.mo_energy)
         gf2 = agf2.AGF2(mf, nmom=(None, None))
         se = gf2.build_se()


### PR DESCRIPTION
Fixes for some of the interface changes in PySCF:

- For some reason you can no longer to `mol.get_hcore()`, replaces with `mf.get_hcore()`
- PySCF broke the `momgfccsd` import chain, I think because they're doing away with MPI completely. I've changed the import pattern.